### PR TITLE
Add go modules and fix a package

### DIFF
--- a/cmd/cm600_exporter/main.go
+++ b/cmd/cm600_exporter/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/nickvanw/cm600_exporter"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -31,7 +32,7 @@ func main() {
 	prometheus.MustRegister(c)
 
 	mux := http.NewServeMux()
-	mux.Handle(*metricsPath, prometheus.Handler())
+	mux.Handle(*metricsPath, promhttp.Handler())
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
 			<head><title>Netgear CM600 Exporter</title></head>

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/nickvanw/cm600_exporter
+
+go 1.13
+
+require (
+	github.com/PuerkitoBio/goquery v1.5.0
+	github.com/gorilla/handlers v1.4.2
+	github.com/northbright/ctx v0.0.0-20161024043329-d1b203ae2564
+	github.com/prometheus/client_golang v1.3.0
+	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
+)


### PR DESCRIPTION
Super excited when I found this today :) It's working great for me.

I added a go.mod support and fixed a changed package name in client_golang

If you have a new version of go like 1.13 you should be able to just clone this into any dir and `go build` it